### PR TITLE
Fix frame compilation. add docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,12 @@ MAVLink.ex
 
 # Intellij
 .idea
+
+# macOS invisibles
+.DS_Store
+
+# Suggested folder to put your MAVLink protocol XML files
+/message_definitions
+
+# Somewhere to generate your output Elixir file
+/output

--- a/README.md
+++ b/README.md
@@ -141,8 +141,9 @@ mix mavlink message_definitions/ardupilotmega.xml output/apm.ex APM
 ```elixir
 defmodule TestLog do
   def start do
-    # MAVLink.Router.subscribe(message: APM.Message.Attitude)
+    # MAVLink.Router.subscribe(message: APM.Message.VfrHud)
     MAVLink.Router.subscribe(message: APM.Message.SysStatus)
+    # MAVLink.Router.subscribe(message: APM.Message.Heartbeat)
     loop()
   end
 
@@ -154,4 +155,6 @@ defmodule TestLog do
     end
   end
 end
+
+TestLog.start()
 ```

--- a/README.md
+++ b/README.md
@@ -2,16 +2,156 @@
 
 _Work in Progress_
 
-A Mix task to generate code from a MAVLink xml definition file, and an 
-application that enables communication with other systems using the 
+A Mix task to generate code from a MAVLink xml definition file, and an
+application that enables communication with other systems using the
 MAVLink 1.0 or 2.0 protocol over serial, UDP and TCP connections.
 
-MAVLink is a Micro Air Vehicle communication protocol used by Pixhawk, 
+MAVLink is a Micro Air Vehicle communication protocol used by Pixhawk,
 Ardupilot and other leading autopilot platforms. For more information
 on MAVLink see https://mavlink.io.
 
 This library is not officially recognised or supported by MAVLink at this
 time. We aim over time to achieve complete compliance with the MAVLink 2.0
 specification, but our initial focus is on using this library on companion
-computers and ground stations for our team entry in the 
+computers and ground stations for our team entry in the
 2020 UAV Outback Challenge https://uavchallenge.org/medical-rescue/.
+
+## Testing locally with Ardupilot, MavProxy, SITL and X-Plane
+
+It's possible to use SITL with X-Plane:
+
+http://ardupilot.org/dev/docs/sitl-with-xplane.html
+
+### Install dependencies:
+
+<!-- Install Python 3:
+
+```
+brew install python
+``` -->
+
+Ensure the above version overrides the built-in Python 2 in macOS, by adding this
+to the end of your `.zshrc` or `.bash_profile`:
+
+```
+export PATH="/usr/local/opt/python/libexec/bin:$PATH"
+```
+
+Verify with: `python --version`.
+
+Remove this incompatible library:
+
+```
+sudo pip uninstall python-dateutil
+```
+
+### Install MavProxy
+
+```
+sudo pip install wxPython
+sudo pip install gnureadline
+sudo pip install billiard
+sudo pip install numpy pyparsing
+sudo pip install MAVProxy
+```
+
+### Ardupilot
+
+Install Ardupilot dependencies:
+
+```
+brew tap ardupilot/homebrew-px4
+brew install genromfs
+brew install gcc-arm-none-eabi
+brew install gawk
+```
+
+Download Ardupilot:
+
+```
+git clone git@github.com:ArduPilot/ardupilot.git
+```
+
+Build Ardupilot for macOS:
+
+```
+brew uninstall binutils
+cd ardupilot
+./Tools/environment_install/install-prereqs-mac.sh
+```
+
+Configure Ardupilot for SITL:
+
+./waf configure --board sitl
+
+And run Arducopter:
+
+```bash
+cd ardupilot/ArduCopter
+cd ArduCopter
+sim_vehicle.py -w
+```
+
+Start X-Plane and set up the data export settings per web page, then run arduplane and mavproxy
+
+mavproxy.py --master=tcp:127.0.0.1:5760 --out 127.0.0.1:14550
+
+Then
+
+```bash
+mix run scripts/listen.exs
+```
+
+will receive messages
+
+## to kill emlid noise bug in mavproxy:
+
+```
+set shownoise False
+```
+
+Which can also be added to `~/.mavinit.scr` to run every time `mavproxy.py` runs.
+
+# Testing against real message definition files
+
+In another directory (like `..`):
+
+```bash
+git clone  git@github.com:mavlink/mavlink.git
+cd elixir-mavlink
+```
+
+The message definitions live in:
+
+```
+message_definitions/v1.0
+```
+
+To generate a protocol file for APM:
+
+```bash
+mkdir message_definitions
+cp ../mavlink/message_definitions/v1.0/\* message_definitions
+
+mix mavlink message_definitions/ardupilotmega.xml output/apm.ex APM
+```
+
+## Example usage
+
+```elixir
+defmodule TestLog do
+  def start do
+    # MAVLink.Router.subscribe(message: APM.Message.Attitude)
+    MAVLink.Router.subscribe(message: APM.Message.SysStatus)
+    loop()
+  end
+
+  def loop do
+    receive do
+      x ->
+        IO.inspect(x)
+        loop()
+    end
+  end
+end
+```

--- a/README.md
+++ b/README.md
@@ -141,9 +141,10 @@ mix mavlink message_definitions/ardupilotmega.xml output/apm.ex APM
 ```elixir
 defmodule TestLog do
   def start do
-    # MAVLink.Router.subscribe(message: APM.Message.VfrHud)
-    MAVLink.Router.subscribe(message: APM.Message.SysStatus)
+    MAVLink.Router.subscribe(message: APM.Message.VfrHud)
+    # MAVLink.Router.subscribe(message: APM.Message.SysStatus)
     # MAVLink.Router.subscribe(message: APM.Message.Heartbeat)
+    # MAVLink.Router.subscribe(message: APM.Message.GlobalPositionInt)
     loop()
   end
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,5 +1,5 @@
 use Mix.Config
 
 config :mavlink, dialect: APM
-config :mavlink, connections: ["udp:192.168.0.23:14550"]
+config :mavlink, connections: ["udp:127.0.0.1:49000"]
 config :logger, level: :info

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,5 +1,5 @@
 use Mix.Config
 
 config :mavlink, dialect: APM
-config :mavlink, connections: ["udp:127.0.0.1:49000"]
+config :mavlink, connections: ["udp:192.168.20.6:14550"]
 config :logger, level: :info

--- a/lib/mavlink/application.ex
+++ b/lib/mavlink/application.ex
@@ -1,13 +1,10 @@
 defmodule MAVLink.Application do
   @moduledoc false
-  
-  
+
   use Application
-  
-  
+
   def start(_, _) do
     children = [MAVLink.Supervisor]
     Supervisor.start_link(children, strategy: :one_for_one)
   end
-  
 end

--- a/lib/mavlink/frame.ex
+++ b/lib/mavlink/frame.ex
@@ -2,50 +2,51 @@ defmodule MAVLink.Frame do
   @moduledoc """
   Represent and work with MAVLink v1/2 message frames
   """
-  
-  
+
   require Logger
-  
-  
-  defstruct [
-    version: 2,
-    payload_length: nil,
-    incompatible_flags: 0,      # MAVLink 2 only
-    compatible_flags: 0,        # MAVLink 2 only
-    sequence_number: nil,
-    source_system_id: nil,
-    source_component_id: nil,
-    message_id: nil,
-    payload: nil,
-    checksum: nil,
-    signature: nil,             # MAVLink 2 signing only (not implemented)
-    raw: nil                    # Original binary frame
-  ]
+  import MAVLink.Utils, only: [x25_crc: 1, x25_crc: 2]
+
+  defstruct version: 2,
+            payload_length: nil,
+            # MAVLink 2 only
+            incompatible_flags: 0,
+            # MAVLink 2 only
+            compatible_flags: 0,
+            sequence_number: nil,
+            source_system_id: nil,
+            source_component_id: nil,
+            message_id: nil,
+            payload: nil,
+            checksum: nil,
+            # MAVLink 2 signing only (not implemented)
+            signature: nil,
+            # Original binary frame
+            raw: nil
+
   @type t :: %MAVLink.Frame{
-                version: 1 | 2,
-                payload_length: 1..255,
-                incompatible_flags: non_neg_integer,
-                compatible_flags: non_neg_integer,
-                sequence_number: 0..255,
-                source_system_id: 1..255,
-                source_component_id: 1..255,
-                message_id: non_neg_integer,
-                payload: binary,
-                checksum: pos_integer,
-                raw: binary
-             }
-             
- 
-  @spec from_binary(binary) :: {MAVLink.Frame.t, binary} | binary
-  def from_binary(raw_and_rest=<<0xfe, # MAVLink version 1
-      payload_length::unsigned-integer-size(8),
-      sequence_number::unsigned-integer-size(8),
-      source_system_id::unsigned-integer-size(8),
-      source_component_id::unsigned-integer-size(8),
-      message_id::unsigned-integer-size(8),
-      payload::binary-size(payload_length),
-      checksum::little-unsigned-integer-size(16),
-      rest::binary>>) do
+          version: 1 | 2,
+          payload_length: 1..255,
+          incompatible_flags: non_neg_integer,
+          compatible_flags: non_neg_integer,
+          sequence_number: 0..255,
+          source_system_id: 1..255,
+          source_component_id: 1..255,
+          message_id: non_neg_integer,
+          payload: binary,
+          checksum: pos_integer,
+          raw: binary
+        }
+
+  @spec from_binary(binary) :: {MAVLink.Frame.t(), binary} | binary
+  # MAVLink version 1
+  def from_binary(
+        raw_and_rest =
+          <<0xFE, payload_length::unsigned-integer-size(8),
+            sequence_number::unsigned-integer-size(8), source_system_id::unsigned-integer-size(8),
+            source_component_id::unsigned-integer-size(8), message_id::unsigned-integer-size(8),
+            payload::binary-size(payload_length), checksum::little-unsigned-integer-size(16),
+            rest::binary>>
+      ) do
     {
       %MAVLink.Frame{
         version: 1,
@@ -56,31 +57,33 @@ defmodule MAVLink.Frame do
         message_id: message_id,
         payload: payload,
         checksum: checksum,
-        raw: binary_part(
-          raw_and_rest,
-          0,
-          byte_size(raw_and_rest) - byte_size(rest))
+        raw:
+          binary_part(
+            raw_and_rest,
+            0,
+            byte_size(raw_and_rest) - byte_size(rest)
+          )
       },
       rest
     }
   end
-  
-  def from_binary(raw_and_rest=<<0xfd, # MAVLink version 2
-      payload_length::unsigned-integer-size(8),
-      0::unsigned-integer-size(8),
-      compatible_flags::unsigned-integer-size(8),
-      sequence_number::unsigned-integer-size(8),
-      source_system_id::unsigned-integer-size(8),
-      source_component_id::unsigned-integer-size(8),
-      message_id::little-unsigned-integer-size(24),
-      payload::binary-size(payload_length),
-      checksum::little-unsigned-integer-size(16),
-      rest::binary>>) do
+
+  # MAVLink version 2
+  def from_binary(
+        raw_and_rest =
+          <<0xFD, payload_length::unsigned-integer-size(8), 0::unsigned-integer-size(8),
+            compatible_flags::unsigned-integer-size(8), sequence_number::unsigned-integer-size(8),
+            source_system_id::unsigned-integer-size(8),
+            source_component_id::unsigned-integer-size(8),
+            message_id::little-unsigned-integer-size(24), payload::binary-size(payload_length),
+            checksum::little-unsigned-integer-size(16), rest::binary>>
+      ) do
     {
       %MAVLink.Frame{
         version: 2,
         payload_length: payload_length,
-        incompatible_flags: 0,                # TODO handle incompatible flags
+        # TODO handle incompatible flags
+        incompatible_flags: 0,
         compatible_flags: compatible_flags,
         sequence_number: sequence_number,
         source_system_id: source_system_id,
@@ -88,45 +91,64 @@ defmodule MAVLink.Frame do
         message_id: message_id,
         payload: payload,
         checksum: checksum,
-        raw: binary_part(
-          raw_and_rest,
-          0,
-          byte_size(raw_and_rest) - byte_size(rest))
+        raw:
+          binary_part(
+            raw_and_rest,
+            0,
+            byte_size(raw_and_rest) - byte_size(rest)
+          )
       },
       rest
     }
   end
-                           
+
   def from_binary(<<_, rest::binary>>), do: from_binary(rest)
   def from_binary(<<>>), do: <<>>
-  
+
   # TODO MAVLink.Dialect protocol to replace "module", change MAVLink.Pack to MAVLink.Message?
-  @spec validate_and_unpack(MAVLink.Frame, module) :: {:ok, MAVLink.Pack.t} | :failed_to_unpack | :checksum_invalid | :unknown_message
-  def validate(frame, dialect) do
+  @spec validate(MAVLink.Frame, module) ::
+          {:ok, MAVLink.Pack.t()} | :failed_to_unpack | :checksum_invalid | :unknown_message
+  def validate(
+        frame = %MAVLink.Frame{
+          version: 1,
+          payload_length: payload_length,
+          sequence_number: sequence_number,
+          source_system_id: source_system_id,
+          source_component_id: source_component_id,
+          message_id: message_id,
+          payload: payload,
+          checksum: checksum,
+          raw: raw
+        },
+        dialect
+      ) do
     case apply(dialect, :msg_attributes, [message_id]) do
       {:ok, crc, expected_length, targeted?} ->
-        if checksum == (
-               :binary.bin_to_list(
-                  frame.raw,
-                  {1, frame.payload_length + elem({0, 5, 9}, frame.version)})
-                |> x25_crc()
-                |> x25_crc([crc])) do
+        if checksum ==
+             :binary.bin_to_list(
+               frame.raw,
+               {1, frame.payload_length + elem({0, 5, 9}, frame.version)}
+             )
+             |> x25_crc()
+             |> x25_crc([crc]) do
           payload_truncated_length = 8 * (expected_length - frame.payload_length)
+
           case apply(dialect, :unpack, [
-            message_id,
-            payload <> <<0::size(payload_truncated_length)>>]) do
+                 message_id,
+                 payload <> <<0::size(payload_truncated_length)>>
+               ]) do
             {:ok, message} ->
               {:ok, message}
+
             _ ->
               :failed_to_unpack
           end
         else
           :checksum_invalid
         end
+
       _ ->
         :unknown_message
     end
   end
-  
-
 end

--- a/lib/mavlink/router.ex
+++ b/lib/mavlink/router.ex
@@ -3,66 +3,85 @@ defmodule MAVLink.Router do
   Connect to serial, udp and tcp ports and listen for, validate and
   forward MAVLink messages towards their destinations on other connections
   and/or Elixir processes subscribing to messages.
-  
+
   The rules for MAVLink packet forwarding are described here:
-  
+
     https://mavlink.io/en/guide/routing.html
-  
+
   and here:
-  
+
     http://ardupilot.org/dev/docs/mavlink-routing-in-ardupilot.html
   """
-  
+
   use GenServer
   require Logger
-  
+
   import MAVLink.Pack
-  import MAVLink.Utils, only: [parse_ip_address: 1, parse_positive_integer: 1, x25_crc: 1, x25_crc: 2]
+
+  import MAVLink.Utils,
+    only: [parse_ip_address: 1, parse_positive_integer: 1, x25_crc: 1, x25_crc: 2]
+
   import Enum, only: [reduce: 3, filter: 2]
-  
-  
+
   # Router state
 
-  defstruct [
-    dialect: nil,                             # Generated dialect module
-    system_id: 25,                            # Default to ground station
+  defstruct
+    # Generated dialect module
+    dialect: nil,
+    # Default to ground station
+    system_id: 25,
     component_id: 250,
-    connection_strings: [],                   # Connection descriptions from user
-    connections: %{},                         # MAVLink.UDP|TCP|Serial_Connection
-    system_component_connection_version: %{}, # Connection and MAVLink version keyed by {system_id, component_id} addresses
-    subscriptions: [],                        # Elixir process queries
-    sequence_number: 0,                       # Sequence number of next sent message
-    uarts: []                                 # Circuit.UART Pool
-  ]
-  @type mavlink_address :: MAVLink.Types.mavlink_address  # Can't used qualified type as map key
-  @type t :: %MAVLink.Router{
-               dialect: module | nil,
-               system_id: non_neg_integer,
-               component_id: non_neg_integer,
-               connection_strings: [ String.t ],
-               connections: %{tuple: MAVLink.Types.connection},
-               system_component_connection_version: %{mavlink_address: {tuple, non_neg_integer}},
-               subscriptions: [],
-               sequence_number: non_neg_integer,
-               uarts: [pid]
-             }
-  
-  
+    # Connection descriptions from user
+    connection_strings: [],
+    # MAVLink.UDP|TCP|Serial_Connection
+    connections: %{},
+    # Connection and MAVLink version keyed by {system_id, component_id} addresses
+    system_component_connection_version: %{},
+    # Elixir process queries
+    subscriptions: [],
+    # Sequence number of next sent message
+    sequence_number: 0,
+    # Circuit.UART Pool
+    uarts: []
+
+  # Can't used qualified type as map key
+  @type mavlink_address :: MAVLink.Types.mavlink_address()
+  @type t ::
+    %MAVLink.Router{
+      dialect: module | nil,
+      system_id: non_neg_integer,
+      component_id: non_neg_integer,
+      connection_strings: [String.t()],
+      connections: %{tuple: MAVLink.Types.connection()},
+      system_component_connection_version: %{mavlink_address: {tuple, non_neg_integer}},
+      subscriptions: [],
+      sequence_number: non_neg_integer,
+      uarts: [pid]
+    }
+
   # Client API
-  @spec start_link(%{dialect: module, system_id: non_neg_integer, component_id: non_neg_integer,
-    connection_strings: [String.t]}, [{atom, any}]) :: {:ok, pid}
+  @spec
+    start_link(
+      %{
+        dialect: module,
+        system_id: non_neg_integer,
+        component_id: non_neg_integer,
+        connection_strings: [String.t()]
+      },
+      [{atom, any}]
+    ) :: {:ok, pid}
   def start_link(state, opts \\ []) do
     GenServer.start_link(
       __MODULE__,
       state,
-      [{:name, __MODULE__} | opts])
+      [{:name, __MODULE__} | opts]
+    )
   end
-  
-  
+
   @doc """
   Subscribes the calling process to messages matching the query.
   Zero or more of the following query keywords are supported:
-  
+
     message:             message_module
     source_system_id:    integer 0..255
     source_component_id: integer 0..255
@@ -70,16 +89,21 @@ defmodule MAVLink.Router do
     target_component_id: integer 0..255
     
   For example:
-  
+
   ```
     MAVLink.Router.subscribe message: MAVLink.Message.Heartbeat, source_system_id: 1
   ```
   """
-  @type subscribe_query_id_key :: :source_system_id | :source_component_id | :target_system_id | :target_component_id
+  @type
+    subscribe_query_id_key ::
+      :source_system_id |
+      :source_component_id |
+      :target_system_id |
+      :target_component_id
   @spec subscribe([{:message, MAVLink.Pack.t()} | {subscribe_query_id_key, 0..255}]) :: :ok
   def subscribe(query \\ []) do
     with message <- Keyword.get(query, :message),
-        true <- message == nil or Code.ensure_loaded?(message) do
+         true <- message == nil or Code.ensure_loaded?(message) do
       GenServer.cast(
         __MODULE__,
         {
@@ -101,8 +125,7 @@ defmodule MAVLink.Router do
         {:error, :invalid_message}
     end
   end
-  
-  
+
   @doc """
   Unsubscribes calling process from all existing subscriptions
   """
@@ -116,8 +139,7 @@ defmodule MAVLink.Router do
       }
     )
   end
-  
-  
+
   @doc """
   Send a MAVLink message to one or more recipients using available
   connections. For now if destination is unreachable it will fail
@@ -125,11 +147,14 @@ defmodule MAVLink.Router do
   """
   def send(message) do
     {:ok, msg_id, {:ok, crc_extra, _, targeted?}, packed} = pack(message)
-    {target_system_id, target_component_id} = if targeted? do
-      {message.target_system, message.target_component}
-    else
-      {0, 0}
-    end
+
+    {target_system_id, target_component_id} =
+      if targeted? do
+        {message.target_system, message.target_component}
+      else
+        {0, 0}
+      end
+
     GenServer.cast(
       __MODULE__,
       {
@@ -142,58 +167,66 @@ defmodule MAVLink.Router do
       }
     )
   end
-  
+
   # Callbacks
-  
+
   @impl true
   def init(%{dialect: nil}) do
     {:error, :no_mavlink_dialect_set}
   end
-  
+
   def init(state = %{connection_strings: connection_strings}) do
     {
       :ok,
       reduce(connection_strings, struct(MAVLink.Router, state), &connect/2)
     }
   end
-  
-  
+
   @impl true
   def handle_cast({:subscribe, query, pid}, state) do
     # Monitor so that we can unsubscribe dead processes
     Process.monitor(pid)
-    
+
     # Uniq prevents duplicate subscriptions
-    {:noreply, %MAVLink.Router{state | subscriptions: Enum.uniq([{query, pid} | state.subscriptions])}}
+    {:noreply,
+     %MAVLink.Router{state | subscriptions: Enum.uniq([{query, pid} | state.subscriptions])}}
   end
-  
+
   def handle_cast({:unsubscribe, pid}, state) do
-    {:noreply, %MAVLink.Router{state | subscriptions: filter(state.subscriptions, & not match?({_, ^pid}, &1))}}
+    {:noreply,
+     %MAVLink.Router{
+       state
+       | subscriptions: filter(state.subscriptions, &(not match?({_, ^pid}, &1)))
+     }}
   end
-  
+
   # TODO should we allow "loopback" sends that just go to local subscribers?
-  def handle_cast({:send, msg_id, target_system_id, target_component_id,
-    packed_payload, crc_extra}, state) do
+  def handle_cast(
+      {:send, msg_id, target_system_id, target_component_id, packed_payload, crc_extra},
+      state
+    ) do
     {mavlink_1_frame, state_next_seq} = pack_frame(1, msg_id, packed_payload, crc_extra, state)
     {mavlink_2_frame, _} = pack_frame(2, msg_id, packed_payload, crc_extra, state)
-    for {_, {connection, mavlink_version}} <- matching_system_components(
-      target_system_id, target_component_id, state_next_seq) do
-        forward(
-          connection,
-          case mavlink_version do
-            1 ->
-              mavlink_1_frame
-            2 ->
-              mavlink_2_frame
-          end,
-          state
-        )
+
+    for {_, {connection, mavlink_version}} <-
+          matching_system_components(target_system_id, target_component_id, state_next_seq) do
+      forward(
+        connection,
+        case mavlink_version do
+          1 ->
+            mavlink_1_frame
+
+          2 ->
+            mavlink_2_frame
+        end,
+        state
+      )
     end
+
     # We only want to advance the sequence number once
     {:noreply, state_next_seq}
   end
-  
-  
+
   @doc """
   Unsubscribe dead subscribers first, then incoming messages from connections
   """
@@ -201,16 +234,24 @@ defmodule MAVLink.Router do
   def handle_info({:DOWN, _, :process, pid, _}, state) do
     {
       :noreply,
-      %MAVLink.Router{state | subscriptions: filter(state.subscriptions, & not match?({_, ^pid}, &1))}
+      %MAVLink.Router{
+        state
+        | subscriptions: filter(state.subscriptions, &(not match?({_, ^pid}, &1)))
+      }
     }
   end
-  
-  def handle_info(message = {:udp, _, _, _, _}, state), do: MAVLink.UDPConnection.handle_info(message, state)
-  def handle_info(message = {:tcp, _, _, _, _}, state), do: MAVLink.TCPConnection.handle_info(message, state)
-  def handle_info(message = {:serial, _, _, _, _}, state), do: MAVLink.SerialConnection.handle_info(message, state)
+
+  def handle_info(message = {:udp, _, _, _, _}, state),
+    do: MAVLink.UDPConnection.handle_info(message, state)
+
+  def handle_info(message = {:tcp, _, _, _, _}, state),
+    do: MAVLink.TCPConnection.handle_info(message, state)
+
+  def handle_info(message = {:serial, _, _, _, _}, state),
+    do: MAVLink.SerialConnection.handle_info(message, state)
+
   def handle_info(_, state), do: {:noreply, state}
-  
-  
+
   #  Use callbacks from generated MAVLink dialect module to ensure
   #  message checksum matches, restore trailing zero bytes if truncation
   #  occurred and unpack the message payload. See:
@@ -220,152 +261,195 @@ defmodule MAVLink.Router do
   #  for purpose of this and following functions.
   def validate_and_route_message_frame(
         state = %MAVLink.Router{dialect: dialect},
-        receiving_connection, mavlink_version, _sequence_number,
-        source_system_id, source_component_id,
-        message_id, payload_length, payload, checksum, raw) do
+        receiving_connection,
+        mavlink_version,
+        _sequence_number,
+        source_system_id,
+        source_component_id,
+        message_id,
+        payload_length,
+        payload,
+        checksum,
+        raw
+      ) do
     case apply(dialect, :msg_attributes, [message_id]) do
       {:ok, crc, expected_length, targeted?} ->
-        case checksum == (
+        case checksum ==
                :binary.bin_to_list(
-                  raw,
-                  {1, payload_length + elem({0, 5, 9}, mavlink_version)})
-                |> x25_crc()
-                |> x25_crc([crc])) do
+                 raw,
+                 {1, payload_length + elem({0, 5, 9}, mavlink_version)}
+               )
+               |> x25_crc()
+               |> x25_crc([crc]) do
           true ->
             payload_truncated_length = 8 * (expected_length - payload_length)
+
             case apply(dialect, :unpack, [
                    message_id,
-                   payload <> <<0::size(payload_truncated_length)>>]) do
+                   payload <> <<0::size(payload_truncated_length)>>
+                 ]) do
               {:ok, message} ->
                 state
-                |> route_message_remote(
-                     receiving_connection,
-                     mavlink_version,
-                     message, raw)
-                |> route_message_local( # TODO local becomes new connection type
-                     source_system_id, source_component_id, targeted?,
-                     message) # TODO add sequence number
+                |> route_message_remote(receiving_connection, mavlink_version, message, raw)
+                # TODO local becomes new connection type
+                |> route_message_local(
+                  source_system_id,
+                  source_component_id,
+                  targeted?,
+                  # TODO add sequence number
+                  message
+                )
                 |> update_route_info(
-                     receiving_connection, mavlink_version,
-                     source_system_id, source_component_id)
+                  receiving_connection,
+                  mavlink_version,
+                  source_system_id,
+                  source_component_id
+                )
+
               _ ->
                 # Couldn't unpack message
-                Logger.info "Couldn't unpack #{inspect(raw)}"
+                Logger.info("Couldn't unpack #{inspect(raw)}")
                 state
             end
+
           _ ->
             # Checksum didn't match
-            Logger.info "Checksum didn't match #{inspect(raw)}"
+            Logger.info("Checksum didn't match #{inspect(raw)}")
             state
         end
+
       {:error, _} ->
         # TODO Message id not in dialect MAVLink says we should broadcast anyway but won't it bounce forever?
-        Logger.info "Message id not in dialect #{inspect(raw)}"
+        Logger.info("Message id not in dialect #{inspect(raw)}")
         state
     end
   end
-  
-  
+
   # Helpers
-  
+
   defp connect(connection_string, state) when is_binary(connection_string) do
     connect(String.split(connection_string, [":", ","]), state)
   end
-  
-  defp connect(tokens = ["serial" | _], state), do: MAVLink.SerialConnection.connect(tokens, state)
-  defp connect(tokens = ["udp" | _], state), do: MAVLink.UDPConnection.connect(validate_address_and_port(tokens), state)
-  defp connect(tokens = ["tcp" | _], state), do: MAVLink.TCPConnection.connect(validate_address_and_port(tokens), state)
-  defp connect([invalid_protocol | _], _), do: raise ArgumentError, message: "invalid protocol #{invalid_protocol}"
 
-  
+  defp connect(tokens = ["serial" | _], state),
+    do: MAVLink.SerialConnection.connect(tokens, state)
+
+  defp connect(tokens = ["udp" | _], state),
+    do: MAVLink.UDPConnection.connect(validate_address_and_port(tokens), state)
+
+  defp connect(tokens = ["tcp" | _], state),
+    do: MAVLink.TCPConnection.connect(validate_address_and_port(tokens), state)
+
+  defp connect([invalid_protocol | _], _),
+    do: raise(ArgumentError, message: "invalid protocol #{invalid_protocol}")
+
   defp validate_address_and_port([protocol, address, port]) do
     case {parse_ip_address(address), parse_positive_integer(port)} do
-      {{:error, :invalid_ip_address}, _}->
+      {{:error, :invalid_ip_address}, _} ->
         raise ArgumentError, message: "invalid ip address #{address}"
+
       {_, :error} ->
         raise ArgumentError, message: "invalid port #{port}"
+
       {parsed_address, parsed_port} ->
         [protocol, parsed_address, parsed_port]
     end
   end
-  
-  
+
   # Known system/components matching target with 0 wildcard
-  defp matching_system_components(q_system_id, q_component_id,
-         %MAVLink.Router{system_component_connection_version: sccv}) do
+  defp matching_system_components(q_system_id, q_component_id, %MAVLink.Router{
+         system_component_connection_version: sccv
+       }) do
     Enum.filter(
       sccv,
       fn {{sid, cid}, _} ->
-          (q_system_id == 0 or q_system_id == sid) and
+        (q_system_id == 0 or q_system_id == sid) and
           (q_component_id == 0 or q_component_id == cid)
       end
     )
   end
-  
-  
+
   # Pack a message frame
-  defp pack_frame(1, message_id, packed_payload, crc_extra, state=%MAVLink.Router{
+  defp pack_frame(
+         1,
+         message_id,
+         packed_payload,
+         crc_extra,
+         state = %MAVLink.Router{
            sequence_number: sequence_number,
            system_id: source_system_id,
            component_id: source_component_id
-         }) do
+         }
+       ) do
     payload_length = byte_size(packed_payload)
-    frame = <<payload_length::unsigned-integer-size(8),
-              sequence_number::unsigned-integer-size(8),
-              source_system_id::unsigned-integer-size(8),
-              source_component_id::unsigned-integer-size(8),
-              message_id::little-unsigned-integer-size(8),
-              packed_payload::binary()>>
+
+    frame =
+      <<payload_length::unsigned-integer-size(8), sequence_number::unsigned-integer-size(8),
+        source_system_id::unsigned-integer-size(8), source_component_id::unsigned-integer-size(8),
+        message_id::little-unsigned-integer-size(8), packed_payload::binary()>>
+
     {
-      <<0xfe>> <> frame <> checksum(frame, crc_extra),
+      <<0xFE>> <> frame <> checksum(frame, crc_extra),
       %MAVLink.Router{state | sequence_number: rem(sequence_number + 1, 255)}
     }
   end
-  
-  defp pack_frame(2, message_id, packed_payload, crc_extra,
-         state=%MAVLink.Router{
+
+  defp pack_frame(
+         2,
+         message_id,
+         packed_payload,
+         crc_extra,
+         state = %MAVLink.Router{
            sequence_number: sequence_number,
            system_id: source_system_id,
            component_id: source_component_id
-         }) do
+         }
+       ) do
     {truncated_length, truncated_payload} = truncate_payload(packed_payload)
-    frame = <<truncated_length::unsigned-integer-size(8),
-              0::unsigned-integer-size(8),  # Incompatible flags
-              0::unsigned-integer-size(8),  # Compatible flags
-              sequence_number::unsigned-integer-size(8),
-              source_system_id::unsigned-integer-size(8),
-              source_component_id::unsigned-integer-size(8),
-              message_id::little-unsigned-integer-size(24),
-              truncated_payload::binary()>>
+
+    frame = <<
+      truncated_length::unsigned-integer-size(8),
+      # Incompatible flags
+      0::unsigned-integer-size(8),
+      # Compatible flags
+      0::unsigned-integer-size(8),
+      sequence_number::unsigned-integer-size(8),
+      source_system_id::unsigned-integer-size(8),
+      source_component_id::unsigned-integer-size(8),
+      message_id::little-unsigned-integer-size(24),
+      truncated_payload::binary()
+    >>
+
     {
-      <<0xfd>> <> frame <> checksum(frame, crc_extra),
+      <<0xFD>> <> frame <> checksum(frame, crc_extra),
       %MAVLink.Router{state | sequence_number: rem(sequence_number + 1, 255)}
     }
   end
-  
-  
+
   # MAVLink 2 truncate trailing 0s in payload
   defp truncate_payload(payload) do
     truncated_payload = String.replace_trailing(payload, <<0>>, "")
+
     if byte_size(truncated_payload) == 0 do
-      {1, <<0>>}  # First byte of payload never truncated
+      # First byte of payload never truncated
+      {1, <<0>>}
     else
       {byte_size(truncated_payload), truncated_payload}
     end
   end
-  
-  
+
   # Calculate checksum
   defp checksum(frame, crc_extra) do
     cs = x25_crc(frame <> <<crc_extra::unsigned-integer-size(8)>>)
     <<cs::little-unsigned-integer-size(16)>>
   end
-  
-  
+
   # Delegate sending a message to connection-type specific code
-  defp forward(connection={:udp, _, _, _}, frame, state), do: MAVLink.UDPConnection.forward(connection, frame, state)
+  defp forward(connection = {:udp, _, _, _}, frame, state),
+    do: MAVLink.UDPConnection.forward(connection, frame, state)
+
   # TODO others
-  
+
   #  Systems should forward messages to another link if any of these conditions hold:
   #
   #  - It is a broadcast message (target_system field omitted or zero).
@@ -378,14 +462,10 @@ defmodule MAVLink.Router do
   #  - Non-broadcast messages must only be sent (or forwarded) to known destinations
   #    (i.e. a system must previously have received a message from the target
   #    system/component).
-  defp route_message_remote(
-         state,
-         _receiving_connection_key,
-         _mavlink_version,
-         _message, _raw) do
-    state # TODO, get send working first
+  defp route_message_remote(state, _receiving_connection_key, _mavlink_version, _message, _raw) do
+    # TODO, get send working first
+    state
   end
-  
 
   #  Forward a message to a subscribing Elixir process. The MAVLink directions are:
   #
@@ -404,28 +484,31 @@ defmodule MAVLink.Router do
   #  MAVLink protocols are implemented by the set of subscribers.
   defp route_message_local(
          state,
-         source_system_id, source_component_id, targeted?,
-         message = %{__struct__: message_type}) do
-    for {
-          %{
-            message: q_message_type,
-            source_system_id: q_source_system_id,
-            source_component_id: q_source_component_id,
-            target_system_id: q_target_system_id,
-            target_component_id: q_target_component_id},
-          pid} <- state.subscriptions do
-      if (q_message_type == nil or q_message_type == message_type)
-          and (q_source_system_id == 0 or q_source_system_id == source_system_id)
-          and (q_source_component_id == 0 or q_source_component_id == source_component_id)
-          and (q_target_system_id == 0 or (targeted? and q_target_system_id == message.target_system))
-          and (q_target_component_id == 0 or (targeted? and q_target_component_id == message.target_system)) do
+         source_system_id,
+         source_component_id,
+         targeted?,
+         message = %{__struct__: message_type}
+       ) do
+    for {%{
+           message: q_message_type,
+           source_system_id: q_source_system_id,
+           source_component_id: q_source_component_id,
+           target_system_id: q_target_system_id,
+           target_component_id: q_target_component_id
+         }, pid} <- state.subscriptions do
+      if (q_message_type == nil or q_message_type == message_type) and
+           (q_source_system_id == 0 or q_source_system_id == source_system_id) and
+           (q_source_component_id == 0 or q_source_component_id == source_component_id) and
+           (q_target_system_id == 0 or (targeted? and q_target_system_id == message.target_system)) and
+           (q_target_component_id == 0 or
+              (targeted? and q_target_component_id == message.target_system)) do
         send(pid, message)
       end
     end
+
     state
   end
-  
-  
+
   #  Map system/component ids to connections on which they have been seen, and
   #  remember version of the most recent message so that we can mirror that
   #  version when sending.
@@ -438,16 +521,20 @@ defmodule MAVLink.Router do
   #  - Responses to SYSTEM_TIME resets are implemented by microservices
   #
   defp update_route_info(
-         state, connection, mavlink_version,
-         source_system_id, source_component_id) do
+         state,
+         connection,
+         mavlink_version,
+         source_system_id,
+         source_component_id
+       ) do
     %MAVLink.Router{
-      state | system_component_connection_version:
-      put_in(
-        state.system_component_connection_version,
-        [{source_system_id, source_component_id}],
-        {connection, mavlink_version}
-      )
+      state
+      | system_component_connection_version:
+          put_in(
+            state.system_component_connection_version,
+            [{source_system_id, source_component_id}],
+            {connection, mavlink_version}
+          )
     }
   end
-  
 end

--- a/lib/mavlink/router.ex
+++ b/lib/mavlink/router.ex
@@ -25,51 +25,49 @@ defmodule MAVLink.Router do
 
   # Router state
 
-  defstruct
-    # Generated dialect module
-    dialect: nil,
-    # Default to ground station
-    system_id: 25,
-    component_id: 250,
-    # Connection descriptions from user
-    connection_strings: [],
-    # MAVLink.UDP|TCP|Serial_Connection
-    connections: %{},
-    # Connection and MAVLink version keyed by {system_id, component_id} addresses
-    system_component_connection_version: %{},
-    # Elixir process queries
-    subscriptions: [],
-    # Sequence number of next sent message
-    sequence_number: 0,
-    # Circuit.UART Pool
-    uarts: []
+  # Generated dialect module
+  defstruct dialect: nil,
+            # Default to ground station
+            system_id: 25,
+            component_id: 250,
+            # Connection descriptions from user
+            connection_strings: [],
+            # MAVLink.UDP|TCP|Serial_Connection
+            connections: %{},
+            # Connection and MAVLink version keyed by {system_id, component_id} addresses
+            system_component_connection_version: %{},
+            # Elixir process queries
+            subscriptions: [],
+            # Sequence number of next sent message
+            sequence_number: 0,
+            # Circuit.UART Pool
+            uarts: []
 
   # Can't used qualified type as map key
   @type mavlink_address :: MAVLink.Types.mavlink_address()
-  @type t ::
-    %MAVLink.Router{
-      dialect: module | nil,
-      system_id: non_neg_integer,
-      component_id: non_neg_integer,
-      connection_strings: [String.t()],
-      connections: %{tuple: MAVLink.Types.connection()},
-      system_component_connection_version: %{mavlink_address: {tuple, non_neg_integer}},
-      subscriptions: [],
-      sequence_number: non_neg_integer,
-      uarts: [pid]
-    }
+  @type t :: %MAVLink.Router{
+          dialect: module | nil,
+          system_id: non_neg_integer,
+          component_id: non_neg_integer,
+          connection_strings: [String.t()],
+          connections: %{tuple: MAVLink.Types.connection()},
+          system_component_connection_version: %{mavlink_address: {tuple, non_neg_integer}},
+          subscriptions: [],
+          sequence_number: non_neg_integer,
+          uarts: [pid]
+        }
 
   # Client API
-  @spec
-    start_link(
-      %{
-        dialect: module,
-        system_id: non_neg_integer,
-        component_id: non_neg_integer,
-        connection_strings: [String.t()]
-      },
-      [{atom, any}]
-    ) :: {:ok, pid}
+  @spec start_link(
+          %{
+            dialect: module,
+            system_id: non_neg_integer,
+            component_id: non_neg_integer,
+            connection_strings: [String.t()]
+          },
+          [{atom, any}]
+        ) :: {:ok, pid}
+
   def start_link(state, opts \\ []) do
     GenServer.start_link(
       __MODULE__,
@@ -94,12 +92,12 @@ defmodule MAVLink.Router do
     MAVLink.Router.subscribe message: MAVLink.Message.Heartbeat, source_system_id: 1
   ```
   """
-  @type
-    subscribe_query_id_key ::
-      :source_system_id |
-      :source_component_id |
-      :target_system_id |
-      :target_component_id
+  @type subscribe_query_id_key ::
+          :source_system_id
+          | :source_component_id
+          | :target_system_id
+          | :target_component_id
+
   @spec subscribe([{:message, MAVLink.Pack.t()} | {subscribe_query_id_key, 0..255}]) :: :ok
   def subscribe(query \\ []) do
     with message <- Keyword.get(query, :message),
@@ -202,9 +200,9 @@ defmodule MAVLink.Router do
 
   # TODO should we allow "loopback" sends that just go to local subscribers?
   def handle_cast(
-      {:send, msg_id, target_system_id, target_component_id, packed_payload, crc_extra},
-      state
-    ) do
+        {:send, msg_id, target_system_id, target_component_id, packed_payload, crc_extra},
+        state
+      ) do
     {mavlink_1_frame, state_next_seq} = pack_frame(1, msg_id, packed_payload, crc_extra, state)
     {mavlink_2_frame, _} = pack_frame(2, msg_id, packed_payload, crc_extra, state)
 

--- a/lib/mavlink/udp_connection.ex
+++ b/lib/mavlink/udp_connection.ex
@@ -2,90 +2,125 @@ defmodule MAVLink.UDPConnection do
   @moduledoc """
   MAVLink.Router delegate for UDP connections
   """
-  
+
   require Logger
   import MAVLink.Router, only: [validate_and_route_message_frame: 11]
-  
-  
-  defstruct [
-    address: nil,
-    port: nil,
-    socket: nil,
-    received: 0,
-    dropped: 0
-  ]
-  @type t :: %MAVLink.UDPConnection{
-               address: MAVLink.Types.net_address,
-               port: MAVLink.Types.net_port,
-               socket: pid,
-               received: non_neg_integer,
-               dropped: non_neg_integer
-             }
-  
-  def handle_info({:udp, sock, source_addr, source_port, raw=
-    <<0xfe, # MAVLink version 1
-      payload_length::unsigned-integer-size(8),
-      sequence_number::unsigned-integer-size(8),
-      source_system_id::unsigned-integer-size(8),
-      source_component_id::unsigned-integer-size(8),
-      message_id::unsigned-integer-size(8),
-      payload::binary-size(payload_length),
-      checksum::little-unsigned-integer-size(16)>>}, state) do
 
+  defstruct address: nil,
+            port: nil,
+            socket: nil,
+            received: 0,
+            dropped: 0
+
+  @type t :: %MAVLink.UDPConnection{
+          address: MAVLink.Types.net_address(),
+          port: MAVLink.Types.net_port(),
+          socket: pid,
+          received: non_neg_integer,
+          dropped: non_neg_integer
+        }
+
+  def handle_info(
+        {
+          :udp,
+          sock,
+          source_addr,
+          source_port,
+          # MAVLink version 1
+          raw =
+            <<0xFE, payload_length::unsigned-integer-size(8),
+              sequence_number::unsigned-integer-size(8),
+              source_system_id::unsigned-integer-size(8),
+              source_component_id::unsigned-integer-size(8), message_id::unsigned-integer-size(8),
+              payload::binary-size(payload_length), checksum::little-unsigned-integer-size(16)>>
+        },
+        state
+      ) do
     {
       :noreply,
-      state |> validate_and_route_message_frame(
-                 {:udp, sock, source_addr, source_port},
-                 1, sequence_number, source_system_id, source_component_id,
-                 message_id, payload_length, payload, checksum, raw)
+      state
+      |> validate_and_route_message_frame(
+        {:udp, sock, source_addr, source_port},
+        1,
+        sequence_number,
+        source_system_id,
+        source_component_id,
+        message_id,
+        payload_length,
+        payload,
+        checksum,
+        raw
+      )
     }
   end
-  
-  def handle_info({:udp, sock, source_addr, source_port, raw=
-    <<0xfd, # MAVLink version 2
-      payload_length::unsigned-integer-size(8),
-      0::unsigned-integer-size(8),   # TODO Rejecting all incompatible flags for now
-      _compatible_flags::unsigned-integer-size(8),
-      sequence_number::unsigned-integer-size(8),
-      source_system_id::unsigned-integer-size(8),
-      source_component_id::unsigned-integer-size(8),
-      message_id::little-unsigned-integer-size(24),
-      payload::binary-size(payload_length),
-      checksum::little-unsigned-integer-size(16)>>}, state) do
-    
+
+  def handle_info(
+        {
+          :udp,
+          sock,
+          source_addr,
+          source_port,
+          # MAVLink version 2
+          raw = <<
+            0xFD,
+            payload_length::unsigned-integer-size(8),
+            # TODO Rejecting all incompatible flags for now
+            0::unsigned-integer-size(8),
+            _compatible_flags::unsigned-integer-size(8),
+            sequence_number::unsigned-integer-size(8),
+            source_system_id::unsigned-integer-size(8),
+            source_component_id::unsigned-integer-size(8),
+            message_id::little-unsigned-integer-size(24),
+            payload::binary-size(payload_length),
+            checksum::little-unsigned-integer-size(16)
+          >>
+        },
+        state
+      ) do
     {
       :noreply,
-      state |> validate_and_route_message_frame(
-                 {:udp, sock, source_addr, source_port},
-                 2, sequence_number, source_system_id, source_component_id,
-                 message_id, payload_length, payload, checksum, raw)
+      state
+      |> validate_and_route_message_frame(
+        {:udp, sock, source_addr, source_port},
+        2,
+        sequence_number,
+        source_system_id,
+        source_component_id,
+        message_id,
+        payload_length,
+        payload,
+        checksum,
+        raw
+      )
     }
   end
-  
-  def handle_info({:udp, _sock, _addr, _port, raw}, state) do
+
+  def handle_info({:udp, _sock, _addr, _port, _raw}, state) do
     # Ignore UDP packets we don't recognise
-    Logger.info "Did not recognise #{inspect(raw)}"
     {:noreply, state}
   end
-  
-  
+
   def connect(["udp", address, port], state) do
-    {:ok, socket} = :gen_udp.open(port, [:binary, ip: address, active: :true])
+    {:ok, socket} = :gen_udp.open(port, [:binary, ip: address, active: true])
+
     %MAVLink.Router{
-      state | connections:
-      put_in(
-        state.connections,
-        [socket],
-        struct(
-          MAVLink.UDPConnection,
-          %{address: address, port: port, socket: socket}))}
+      state
+      | connections:
+          put_in(
+            state.connections,
+            [socket],
+            struct(
+              MAVLink.UDPConnection,
+              %{address: address, port: port, socket: socket}
+            )
+          )
+    }
   end
-  
-  
+
   def forward({:udp, socket, address, port}, frame, state) do
     # Mirror what we sent back through receive code to test
     handle_info({:udp, socket, address, port, frame}, state)
-    {:noreply, state} #TODO
+    # TODO
+    {:noreply, state}
   end
-
 end


### PR DESCRIPTION
* Was getting a compilation error in `frame.ex`, so fixed the dialyzer spec and match correct params.
* Updated `README.md` to have example usage of router and explanations on obtaining message_definition files.
* Set explicit directories for `message_definitions` and `output`, and added them to `.gitignore`.
* Removed really noisy logging when seeing an unrecognised message. It was making debugging anything impossible.